### PR TITLE
Fix install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ sudo: false
 python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install: 
+ - pip install --upgrade setuptools
+ - pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
 script:  
 - python TestSPMResultDataModel.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-rdflib>=4.2.0
 vcrpy>=1.4.1
 ddt
 nidmresults==0.3.4


### PR DESCRIPTION
This pull request add an update of the `setuptools` package before install of the requirements to avoid the following error (e.g. https://travis-ci.org/incf-nidash/nidmresults-spm/builds/156829947):
```
$ pip install -r requirements.txt
Collecting rdflib>=4.2.0 (from -r requirements.txt (line 1))
  Downloading rdflib-4.2.1.tar.gz (889kB)
    100% |################################| 892kB 623kB/s 
Collecting vcrpy>=1.4.1 (from -r requirements.txt (line 2))
  Downloading vcrpy-1.10.0-py2.py3-none-any.whl
Collecting ddt (from -r requirements.txt (line 3))
  Downloading ddt-1.1.0-py2.py3-none-any.whl
Collecting nidmresults==0.3.4 (from -r requirements.txt (line 4))
  Downloading nidmresults-0.3.4-py2.py3-none-any.whl (227kB)
    100% |################################| 229kB 2.0MB/s 
Collecting isodate (from rdflib>=4.2.0->-r requirements.txt (line 1))
  Downloading isodate-0.5.4.tar.gz
Collecting pyparsing (from rdflib>=4.2.0->-r requirements.txt (line 1))
  Downloading pyparsing-2.1.8-py2.py3-none-any.whl (54kB)
    100% |################################| 57kB 261kB/s 
Collecting SPARQLWrapper (from rdflib>=4.2.0->-r requirements.txt (line 1))
  Downloading SPARQLWrapper-1.7.6.zip
Collecting html5lib (from rdflib>=4.2.0->-r requirements.txt (line 1))
  Downloading html5lib-0.999999999.tar.gz (245kB)
    100% |################################| 245kB 1.6MB/s 
    html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)
    Complete output from command python setup.py egg_info:
    html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)
    
    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-aM86Mv/html5lib
```