### PR TITLE
Dependency on nidmresults 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 
  - pip install --upgrade setuptools
- # Install testing version of nidmresults
- - pip install -i https://testpypi.python.org/pypi nidmresults
+  # Install nidmresults from source in GitHub repo
+ - pip install --upgrade --no-deps git+https://github.com/cmaumet/nidmresults.git@no_std_space_coord#egg=nidmresults
  - pip install -r requirements.txt
-# command to run tests, e.g. python setup.py test
+ # command to run tests, e.g. python setup.py test
 script:  
 - python TestSPMResultDataModel.py
 - cat debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 
  - pip install --upgrade setuptools
+ # Install testing version of nidmresults
+ - pip install -i https://testpypi.python.org/pypi nidmresults
  - pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
 script:  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 install: 
  - pip install --upgrade setuptools
   # Install nidmresults from source in GitHub repo
- - pip install --upgrade --no-deps git+https://github.com/cmaumet/nidmresults.git@no_std_space_coord#egg=nidmresults
  - pip install -r requirements.txt
  # command to run tests, e.g. python setup.py test
 script:  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 vcrpy>=1.4.1
 ddt
-nidmresults==1.0.1
+nidmresults>=1.1.0<1.2.0


### PR DESCRIPTION
This PR updates the requirements to depend on `nidmresults` 1.1.0 release.